### PR TITLE
Support Rails 4

### DIFF
--- a/banana.gemspec
+++ b/banana.gemspec
@@ -15,8 +15,8 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Banana::VERSION
 
-  gem.add_dependency 'activerecord', '~> 3.2'
-  gem.add_dependency 'railties', '~> 3.2'
+  gem.add_dependency 'activerecord', '>= 3.2'
+  gem.add_dependency 'railties', '>= 3.2'
 
   gem.add_development_dependency 'rspec'
 end


### PR DESCRIPTION
Hi, @sinsoku 
On Rails4 environment, `rake db:create` and `rake db:drop` seem to not work.
It raise error like this...

```
$ bundle ex rake db:create
rake aborted!
NoMethodError: undefined method `create_database' for main:Object

$ bundle ex rake db:drop
rake aborted!
NoMethodError: undefined method `drop_database_and_rescue' for main:Object
```

So I checked Rails code, and found problem that `create_database` and `drop_database_and_rescue` moved to other file and rewritten.

see@https://github.com/rails/rails/blob/master/activerecord/lib/active_record/tasks/database_tasks.rb
see@https://github.com/rails/rails/blob/master/activerecord/lib/active_record/railties/databases.rake

This PR fix that issue in my environment. Please check and merge.

Regards.
