### PR TITLE
⚠️: Passing a string to ActiveRecord::Base.establish_connection for...

### DIFF
--- a/lib/banana/migration.rb
+++ b/lib/banana/migration.rb
@@ -4,9 +4,9 @@ module ActiveRecord
   class Migration
     def migrate_with_multidb(direction)
       if defined? self.class::DATABASE_NAME
-        ActiveRecord::Base.establish_connection(self.class::DATABASE_NAME)
+        ActiveRecord::Base.establish_connection(self.class::DATABASE_NAME.to_sym)
         migrate_without_multidb(direction)
-        ActiveRecord::Base.establish_connection(Rails.env)
+        ActiveRecord::Base.establish_connection(Rails.env.to_sym)
       else
         migrate_without_multidb(direction)
       end

--- a/lib/banana/tasks/database.rake
+++ b/lib/banana/tasks/database.rake
@@ -16,7 +16,7 @@ db_namespace = namespace :db do
 
   desc "Migrate the database (options: VERSION=x, VERBOSE=false)."
   task :migrate => [:environment, :load_config] do
-    ActiveRecord::Base.establish_connection(Rails.env)
+    ActiveRecord::Base.establish_connection(Rails.env.to_sym)
 
     ActiveRecord::Migration.verbose = ENV["VERBOSE"] ? ENV["VERBOSE"] == "true" : true
     ActiveRecord::Migrator.migrate(ActiveRecord::Migrator.migrations_paths, ENV["VERSION"] ? ENV["VERSION"].to_i : nil) do |migration|
@@ -42,7 +42,7 @@ db_namespace = namespace :db do
       require 'banana/multidb_schema_dumper'
       filename = ENV['SCHEMA'] || "#{Rails.root}/db/schema.rb"
       File.open(filename, "w:utf-8") do |file|
-        environments = ActiveRecord::Base.configurations.keys.select { |x| x =~ /#{Rails.env}$/ }
+        environments = ActiveRecord::Base.configurations.keys.select { |x| x =~ /#{Rails.env}$/ }.map(&:to_sym)
         Banana::MultidbSchemaDumper.dump_multidb(environments, file)
       end
       db_namespace['schema:dump'].reenable


### PR DESCRIPTION
Running migrations on our app spits out this :warning:s on AR 4.1 and 4.2 (not sure on older versions).
https://github.com/rails/rails/blob/00f8e7357b16ea28103f82431c6e31205565a1f0/activerecord/lib/active_record/connection_adapters/connection_specification.rb#L225-L228
